### PR TITLE
feat: implement laboratory scheduling module

### DIFF
--- a/src/app/(protected)/dashboard/scheduling/agenda/page.tsx
+++ b/src/app/(protected)/dashboard/scheduling/agenda/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+import { AgendaList } from "@/features/scheduling/components/agenda-list";
+import { getUpcomingReservations } from "@/features/scheduling/server/queries";
+
+export const metadata: Metadata = {
+  title: "Minha agenda • AcadLab",
+};
+
+export default async function AgendaPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login?callbackUrl=/dashboard/scheduling/agenda");
+  }
+
+  const reservations = await getUpcomingReservations({
+    id: session.user.id,
+    role: session.user.role,
+  });
+
+  return <AgendaList reservations={reservations} actorRole={session.user.role} />;
+}

--- a/src/app/(protected)/dashboard/scheduling/history/page.tsx
+++ b/src/app/(protected)/dashboard/scheduling/history/page.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+import { HistoryTable } from "@/features/scheduling/components/history-table";
+import { getReservationHistory } from "@/features/scheduling/server/queries";
+
+export const metadata: Metadata = {
+  title: "Histórico de reservas • AcadLab",
+};
+
+export default async function HistoryPage() {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login?callbackUrl=/dashboard/scheduling/history");
+  }
+
+  const reservations = await getReservationHistory({
+    id: session.user.id,
+    role: session.user.role,
+  });
+
+  return <HistoryTable reservations={reservations} actorRole={session.user.role} />;
+}

--- a/src/app/(protected)/dashboard/scheduling/page.tsx
+++ b/src/app/(protected)/dashboard/scheduling/page.tsx
@@ -1,0 +1,73 @@
+import type { Metadata } from "next";
+import { redirect } from "next/navigation";
+
+import { auth } from "@/auth";
+import { SchedulingBoard } from "@/features/scheduling/components/scheduling-board";
+import {
+  getActiveLaboratoryOptions,
+  getSchedulingBoardData,
+  normalizeDateParam,
+} from "@/features/scheduling/server/queries";
+import type { SearchParamsLike } from "@/features/shared/search-params";
+import { resolveSearchParams } from "@/features/shared/search-params";
+
+export const metadata: Metadata = {
+  title: "Agenda de laboratórios • AcadLab",
+};
+
+type SchedulingSearchParams = {
+  laboratoryId?: string | string[];
+  date?: string | string[];
+};
+
+export default async function SchedulingPage({
+  searchParams,
+}: {
+  searchParams?: SearchParamsLike<SchedulingSearchParams>;
+}) {
+  const session = await auth();
+
+  if (!session?.user) {
+    redirect("/login?callbackUrl=/dashboard/scheduling");
+  }
+
+  const resolvedParams = await resolveSearchParams<SchedulingSearchParams>(searchParams);
+  const laboratories = await getActiveLaboratoryOptions();
+
+  if (laboratories.length === 0) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-muted/40 p-8 text-center">
+        <h1 className="text-2xl font-semibold text-foreground">Agenda de laboratórios</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Nenhum laboratório ativo foi encontrado. Cadastre um laboratório para iniciar os agendamentos.
+        </p>
+      </div>
+    );
+  }
+
+  const requestedLaboratoryId = Array.isArray(resolvedParams?.laboratoryId)
+    ? resolvedParams.laboratoryId[0]
+    : resolvedParams?.laboratoryId;
+  const selectedLaboratoryId = laboratories.some((lab) => lab.id === requestedLaboratoryId)
+    ? requestedLaboratoryId!
+    : laboratories[0]!.id;
+
+  const selectedDate = normalizeDateParam(resolvedParams?.date);
+  const now = new Date();
+
+  const schedule = await getSchedulingBoardData({
+    laboratoryId: selectedLaboratoryId,
+    date: selectedDate,
+    now,
+  });
+
+  return (
+    <SchedulingBoard
+      laboratories={laboratories}
+      selectedLaboratoryId={selectedLaboratoryId}
+      selectedDate={selectedDate}
+      schedule={schedule}
+      actorRole={session.user.role}
+    />
+  );
+}

--- a/src/features/dashboard/components/protected-shell.tsx
+++ b/src/features/dashboard/components/protected-shell.tsx
@@ -169,6 +169,8 @@ function buildBreadcrumbItems(segments: string[]) {
     dashboard: "Painel",
     laboratories: "Laboratórios",
     scheduling: "Agenda",
+    agenda: "Minha agenda",
+    history: "Histórico de reservas",
     software: "Softwares",
     profile: "Meu perfil",
     users: "Usuários",

--- a/src/features/dashboard/constants/modules.ts
+++ b/src/features/dashboard/constants/modules.ts
@@ -40,7 +40,7 @@ export const DASHBOARD_MODULES: DashboardModule[] = [
     href: "/dashboard/scheduling",
     roles: ALL_ROLES,
     icon: ClipboardList,
-    status: "coming-soon",
+    status: "available",
   },
   {
     id: "software-maintenance",

--- a/src/features/scheduling/components/agenda-list.tsx
+++ b/src/features/scheduling/components/agenda-list.tsx
@@ -1,0 +1,98 @@
+import { Role } from "@prisma/client";
+import { CalendarDays, Clock, User } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { AgendaReservation } from "@/features/scheduling/types";
+
+interface AgendaListProps {
+  reservations: AgendaReservation[];
+  actorRole: Role;
+}
+
+const statusLabels = {
+  CONFIRMED: "Confirmada",
+  PENDING: "Pendente",
+  CANCELLED: "Cancelada",
+} as const;
+
+export function AgendaList({ reservations, actorRole }: AgendaListProps) {
+  const canSeeAllUsers = actorRole === Role.ADMIN || actorRole === Role.TECHNICIAN;
+  const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+  const timeFormatter = new Intl.DateTimeFormat("pt-BR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <p className="text-sm font-medium text-primary/80">Próximas reservas</p>
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">Minha agenda</h1>
+          <p className="text-sm text-muted-foreground">
+            Consulte abaixo os próximos horários confirmados. Atualizações são aplicadas automaticamente após novos agendamentos.
+          </p>
+        </div>
+      </header>
+
+      {reservations.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-10 text-center">
+          <CalendarDays className="mx-auto size-10 text-muted-foreground" aria-hidden />
+          <h2 className="mt-4 text-xl font-semibold text-foreground">Nenhuma reserva futura</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Assim que novas reservas forem registradas, elas aparecerão aqui.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4">
+          {reservations.map((reservation) => {
+            const start = new Date(reservation.startTime);
+            const end = new Date(reservation.endTime);
+            const dateLabel = dateFormatter.format(start);
+            const timeLabel = `${timeFormatter.format(start)} - ${timeFormatter.format(end)}`;
+            const statusLabel = statusLabels[reservation.status];
+
+            return (
+              <Card key={reservation.id} className="border-border/70">
+                <CardHeader className="flex flex-col gap-1">
+                  <CardTitle className="text-xl text-foreground">
+                    {reservation.laboratory.name}
+                  </CardTitle>
+                  <p className="text-sm text-muted-foreground capitalize">{dateLabel}</p>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm">
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <Clock className="size-4" aria-hidden />
+                    <span>{timeLabel}</span>
+                  </div>
+                  {canSeeAllUsers ? (
+                    <div className="flex items-center gap-2 text-muted-foreground">
+                      <User className="size-4" aria-hidden />
+                      <span>
+                        Responsável: <strong className="text-foreground">{reservation.createdBy.name}</strong>
+                      </span>
+                    </div>
+                  ) : null}
+                  <div className="flex items-center gap-2 text-muted-foreground">
+                    <span className="inline-flex items-center gap-2 rounded-full bg-primary/10 px-3 py-1 text-xs font-medium text-primary">
+                      {statusLabel}
+                    </span>
+                    {reservation.recurrenceId ? (
+                      <span className="rounded-full bg-muted px-3 py-1 text-xs text-muted-foreground">
+                        Reserva recorrente
+                      </span>
+                    ) : null}
+                  </div>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/scheduling/components/date-picker-calendar.tsx
+++ b/src/features/scheduling/components/date-picker-calendar.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface DatePickerCalendarProps {
+  selectedDate: string;
+  onSelect: (date: string) => void;
+}
+
+const WEEKDAY_LABELS = ["Dom", "Seg", "Ter", "Qua", "Qui", "Sex", "Sáb"];
+
+export function DatePickerCalendar({ selectedDate, onSelect }: DatePickerCalendarProps) {
+  const initialMonth = useMemo(() => startOfMonth(parseIsoDate(selectedDate)), [selectedDate]);
+  const [visibleMonth, setVisibleMonth] = useState(initialMonth);
+
+  useEffect(() => {
+    setVisibleMonth(initialMonth);
+  }, [initialMonth]);
+
+  const calendarDays = useMemo(() => buildCalendarDays(visibleMonth), [visibleMonth]);
+  const selectedIso = normalizeDate(selectedDate);
+  const todayIso = normalizeDate(new Date().toISOString().slice(0, 10));
+
+  const monthLabel = new Intl.DateTimeFormat("pt-BR", {
+    month: "long",
+    year: "numeric",
+  }).format(visibleMonth);
+
+  const handlePrevious = () => {
+    setVisibleMonth((current) => addMonths(current, -1));
+  };
+
+  const handleNext = () => {
+    setVisibleMonth((current) => addMonths(current, 1));
+  };
+
+  return (
+    <div className="w-full rounded-lg border border-border/60 bg-background/95 shadow-sm">
+      <div className="flex items-center justify-between border-b border-border/60 px-3 py-2">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7 text-muted-foreground"
+          onClick={handlePrevious}
+          aria-label="Mês anterior"
+        >
+          <ChevronLeft className="size-4" aria-hidden />
+        </Button>
+        <div className="text-sm font-semibold capitalize text-foreground">
+          {monthLabel}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7 text-muted-foreground"
+          onClick={handleNext}
+          aria-label="Próximo mês"
+        >
+          <ChevronRight className="size-4" aria-hidden />
+        </Button>
+      </div>
+      <div className="grid grid-cols-7 gap-1 px-3 py-2 text-xs font-medium text-muted-foreground">
+        {WEEKDAY_LABELS.map((weekday) => (
+          <div key={weekday} className="text-center uppercase tracking-wide">
+            {weekday}
+          </div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7 gap-1 px-3 pb-3">
+        {calendarDays.map((day) => {
+          const isoDate = normalizeDate(day.date.toISOString().slice(0, 10));
+          const isSelected = isoDate === selectedIso;
+          const isToday = isoDate === todayIso;
+
+          return (
+            <button
+              key={isoDate + (day.currentMonth ? "current" : "other")}
+              type="button"
+              onClick={() => onSelect(isoDate)}
+              className={cn(
+                "flex h-9 w-full items-center justify-center rounded-md text-sm transition-colors",
+                day.currentMonth
+                  ? "text-foreground hover:bg-primary/10"
+                  : "text-muted-foreground/50 hover:bg-muted/40",
+                isSelected && "bg-primary text-primary-foreground hover:bg-primary",
+                !day.currentMonth && isSelected && "opacity-90",
+                isToday && !isSelected && "border border-primary/40",
+              )}
+            >
+              <span>{day.date.getUTCDate()}</span>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+interface CalendarDay {
+  date: Date;
+  currentMonth: boolean;
+}
+
+function buildCalendarDays(monthDate: Date): CalendarDay[] {
+  const year = monthDate.getUTCFullYear();
+  const month = monthDate.getUTCMonth();
+  const firstDayOfMonth = new Date(Date.UTC(year, month, 1));
+  const firstWeekday = firstDayOfMonth.getUTCDay();
+  const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+
+  const days: CalendarDay[] = [];
+
+  const previousMonthDays = firstWeekday;
+  for (let index = previousMonthDays; index > 0; index -= 1) {
+    const date = new Date(Date.UTC(year, month, 1 - index));
+    days.push({ date, currentMonth: false });
+  }
+
+  for (let day = 1; day <= daysInMonth; day += 1) {
+    const date = new Date(Date.UTC(year, month, day));
+    days.push({ date, currentMonth: true });
+  }
+
+  const totalCells = Math.ceil(days.length / 7) * 7;
+  const remaining = totalCells - days.length;
+  for (let index = 1; index <= remaining; index += 1) {
+    const date = new Date(Date.UTC(year, month + 1, index));
+    days.push({ date, currentMonth: false });
+  }
+
+  return days;
+}
+
+function parseIsoDate(value: string): Date {
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    return new Date(`${value}T00:00:00.000Z`);
+  }
+
+  return new Date();
+}
+
+function startOfMonth(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+}
+
+function addMonths(date: Date, months: number): Date {
+  const result = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, 1));
+  return result;
+}
+
+function normalizeDate(value: string): string {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return new Date().toISOString().slice(0, 10);
+  }
+  return value;
+}

--- a/src/features/scheduling/components/history-table.tsx
+++ b/src/features/scheduling/components/history-table.tsx
@@ -1,0 +1,116 @@
+import { Role } from "@prisma/client";
+import { CalendarDays } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { ReservationHistoryEntry } from "@/features/scheduling/types";
+import { cn } from "@/lib/utils";
+
+interface HistoryTableProps {
+  reservations: ReservationHistoryEntry[];
+  actorRole: Role;
+}
+
+const statusLabels = {
+  CONFIRMED: "Confirmada",
+  PENDING: "Pendente",
+  CANCELLED: "Cancelada",
+} as const;
+
+const statusStyles: Record<keyof typeof statusLabels, string> = {
+  CONFIRMED: "bg-emerald-100 text-emerald-700",
+  PENDING: "bg-amber-100 text-amber-700",
+  CANCELLED: "bg-destructive/10 text-destructive",
+};
+
+export function HistoryTable({ reservations, actorRole }: HistoryTableProps) {
+  const canSeeAllUsers = actorRole === Role.ADMIN || actorRole === Role.TECHNICIAN;
+  const dateFormatter = new Intl.DateTimeFormat("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+  const timeFormatter = new Intl.DateTimeFormat("pt-BR", {
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <p className="text-sm font-medium text-primary/80">Histórico completo</p>
+        <div className="space-y-1">
+          <h1 className="text-3xl font-semibold tracking-tight">Reservas registradas</h1>
+          <p className="text-sm text-muted-foreground">
+            Visualize todas as reservas realizadas. Técnicos e administradores conseguem revisar as reservas de qualquer usuário.
+          </p>
+        </div>
+      </header>
+
+      {reservations.length === 0 ? (
+        <div className="rounded-lg border border-dashed border-border/60 bg-muted/30 p-10 text-center">
+          <CalendarDays className="mx-auto size-10 text-muted-foreground" aria-hidden />
+          <h2 className="mt-4 text-xl font-semibold text-foreground">Nenhuma reserva encontrada</h2>
+          <p className="mt-2 text-sm text-muted-foreground">
+            As reservas concluídas ou futuras aparecerão aqui assim que forem cadastradas.
+          </p>
+        </div>
+      ) : (
+        <Card className="border-border/60">
+          <CardHeader>
+            <CardTitle className="text-xl text-foreground">Histórico de agendamentos</CardTitle>
+          </CardHeader>
+          <CardContent className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-border/60 text-left text-sm">
+              <thead className="bg-muted/40">
+                <tr>
+                  <th scope="col" className="px-4 py-3 font-medium text-muted-foreground">Data</th>
+                  <th scope="col" className="px-4 py-3 font-medium text-muted-foreground">Horário</th>
+                  <th scope="col" className="px-4 py-3 font-medium text-muted-foreground">Laboratório</th>
+                  {canSeeAllUsers ? (
+                    <th scope="col" className="px-4 py-3 font-medium text-muted-foreground">Responsável</th>
+                  ) : null}
+                  <th scope="col" className="px-4 py-3 font-medium text-muted-foreground">Status</th>
+                  <th scope="col" className="px-4 py-3 font-medium text-muted-foreground">Recorrência</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-border/60">
+                {reservations.map((reservation) => {
+                  const start = new Date(reservation.startTime);
+                  const end = new Date(reservation.endTime);
+                  const dateLabel = dateFormatter.format(start);
+                  const timeLabel = `${timeFormatter.format(start)} - ${timeFormatter.format(end)}`;
+                  const statusLabel = statusLabels[reservation.status];
+                  const statusStyle = statusStyles[reservation.status];
+
+                  return (
+                    <tr key={reservation.id} className="bg-background/95">
+                      <td className="px-4 py-3 text-foreground">{dateLabel}</td>
+                      <td className="px-4 py-3 text-foreground">{timeLabel}</td>
+                      <td className="px-4 py-3 text-foreground">{reservation.laboratory.name}</td>
+                      {canSeeAllUsers ? (
+                        <td className="px-4 py-3 text-foreground">{reservation.createdBy.name}</td>
+                      ) : null}
+                      <td className="px-4 py-3">
+                        <span
+                          className={cn(
+                            "inline-flex items-center rounded-full px-3 py-1 text-xs font-medium",
+                            statusStyle,
+                          )}
+                        >
+                          {statusLabel}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {reservation.recurrenceId ? "Recorrente" : "Única"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/features/scheduling/components/scheduling-board.tsx
+++ b/src/features/scheduling/components/scheduling-board.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import {
+  useActionState,
+  useEffect,
+  useMemo,
+  useState,
+  useTransition,
+  type ChangeEvent,
+} from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Role, ReservationStatus } from "@prisma/client";
+import { CalendarDays, History, Loader2, RefreshCw } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { idleActionState } from "@/features/shared/types";
+import { DatePickerCalendar } from "@/features/scheduling/components/date-picker-calendar";
+import { createReservationAction } from "@/features/scheduling/server/actions";
+import type {
+  DailySchedule,
+  ReservationSlot,
+  SerializableLaboratoryOption,
+} from "@/features/scheduling/types";
+import { cn } from "@/lib/utils";
+
+interface SchedulingBoardProps {
+  laboratories: SerializableLaboratoryOption[];
+  selectedLaboratoryId: string;
+  selectedDate: string;
+  schedule: DailySchedule;
+  actorRole: Role;
+}
+
+const OCCURRENCE_OPTIONS = Array.from({ length: 12 }, (_, index) => index + 1);
+
+export function SchedulingBoard({
+  laboratories,
+  selectedLaboratoryId,
+  selectedDate,
+  schedule,
+  actorRole,
+}: SchedulingBoardProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isNavigating, startTransition] = useTransition();
+  const [selectedSlots, setSelectedSlots] = useState<Set<string>>(new Set());
+  const [formState, formAction, isSubmitting] = useActionState(
+    createReservationAction,
+    idleActionState,
+  );
+
+  const timeFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat("pt-BR", {
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+    [],
+  );
+
+  const allSlotIds = useMemo(
+    () =>
+      new Set(
+        schedule.periods.flatMap((period) => period.slots.map((slot) => slot.id)),
+      ),
+    [schedule],
+  );
+
+  useEffect(() => {
+    setSelectedSlots((current) => {
+      const filtered = new Set([...current].filter((slotId) => allSlotIds.has(slotId)));
+      return filtered;
+    });
+  }, [allSlotIds]);
+
+  useEffect(() => {
+    if (formState.status === "success") {
+      setSelectedSlots(new Set());
+    }
+  }, [formState.status]);
+
+  useEffect(() => {
+    setSelectedSlots(new Set());
+  }, [selectedLaboratoryId, selectedDate]);
+
+  const selectedSlotIds = useMemo(() => {
+    const ids = Array.from(selectedSlots).filter((slotId) => allSlotIds.has(slotId));
+    ids.sort();
+    return ids;
+  }, [selectedSlots, allSlotIds]);
+
+  const handleLaboratoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextLaboratoryId = event.target.value;
+    const params = new URLSearchParams(searchParams?.toString());
+    params.set("laboratoryId", nextLaboratoryId);
+    startTransition(() => {
+      router.push(`/dashboard/scheduling?${params.toString()}`);
+    });
+  };
+
+  const handleDateSelect = (nextDate: string) => {
+    const params = new URLSearchParams(searchParams?.toString());
+    params.set("date", nextDate);
+    startTransition(() => {
+      router.push(`/dashboard/scheduling?${params.toString()}`);
+    });
+  };
+
+  const toggleSlotSelection = (slot: ReservationSlot) => {
+    if (slot.isOccupied || slot.isPast) {
+      return;
+    }
+
+    setSelectedSlots((current) => {
+      const next = new Set(current);
+      if (next.has(slot.id)) {
+        next.delete(slot.id);
+      } else {
+        next.add(slot.id);
+      }
+      return next;
+    });
+  };
+
+  const formattedDate = useMemo(() => {
+    const date = new Date(`${selectedDate}T00:00:00.000Z`);
+    return new Intl.DateTimeFormat("pt-BR", {
+      weekday: "long",
+      day: "numeric",
+      month: "long",
+    }).format(date);
+  }, [selectedDate]);
+
+  const canScheduleRecurrence = actorRole === Role.ADMIN || actorRole === Role.TECHNICIAN;
+
+  const selectionSummary = useMemo(() => {
+    if (selectedSlotIds.length === 0) {
+      return null;
+    }
+
+    const firstSlot = findSlot(schedule, selectedSlotIds[0]!);
+    const lastSlot = findSlot(schedule, selectedSlotIds[selectedSlotIds.length - 1]!);
+
+    if (!firstSlot || !lastSlot) {
+      return null;
+    }
+
+    const startLabel = timeFormatter.format(new Date(firstSlot.startTime));
+    const endLabel = timeFormatter.format(new Date(lastSlot.endTime));
+
+    return `${selectedSlotIds.length} horário${selectedSlotIds.length > 1 ? "s" : ""} selecionado${
+      selectedSlotIds.length > 1 ? "s" : ""
+    } (${startLabel} - ${endLabel})`;
+  }, [selectedSlotIds, schedule, timeFormatter]);
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-6 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-primary/80">Gestão de agendamentos</p>
+          <div className="space-y-1">
+            <h1 className="text-3xl font-semibold tracking-tight">Agenda de laboratórios</h1>
+            <p className="text-sm text-muted-foreground">
+              Selecione um laboratório, escolha a data no calendário e reserve horários disponíveis.
+              Técnicos e administradores podem ativar recorrência semanal em um só passo.
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <Link
+            href="/dashboard/scheduling/agenda"
+            className="flex items-center gap-2 rounded-md border border-border/60 bg-background px-3 py-2 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-primary/10"
+          >
+            <CalendarDays className="size-4" aria-hidden />
+            Minha agenda
+          </Link>
+          <Link
+            href="/dashboard/scheduling/history"
+            className="flex items-center gap-2 rounded-md border border-border/60 bg-background px-3 py-2 text-sm font-medium text-foreground shadow-sm transition-colors hover:bg-primary/10"
+          >
+            <History className="size-4" aria-hidden />
+            Histórico de reservas
+          </Link>
+        </div>
+      </header>
+
+      <div className="grid gap-8 lg:grid-cols-[320px,1fr]">
+        <aside className="space-y-6">
+          <div className="space-y-2">
+            <label htmlFor="laboratoryId" className="text-sm font-medium text-foreground">
+              Laboratório
+            </label>
+            <select
+              id="laboratoryId"
+              name="laboratoryId"
+              value={selectedLaboratoryId}
+              onChange={handleLaboratoryChange}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+              disabled={isNavigating || laboratories.length === 0}
+            >
+              {laboratories.map((laboratory) => (
+                <option key={laboratory.id} value={laboratory.id}>
+                  {laboratory.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between text-sm">
+              <span className="font-medium text-foreground">Data selecionada</span>
+              {isNavigating ? (
+                <span className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Loader2 className="size-3 animate-spin" aria-hidden /> Atualizando…
+                </span>
+              ) : (
+                <span className="capitalize text-xs text-muted-foreground">{formattedDate}</span>
+              )}
+            </div>
+            <DatePickerCalendar selectedDate={selectedDate} onSelect={handleDateSelect} />
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-muted/40 p-4 text-xs text-muted-foreground">
+            <p className="flex items-center gap-2 font-medium text-foreground">
+              <RefreshCw className="size-3" aria-hidden /> Regras de agendamento
+            </p>
+            <ul className="mt-2 list-disc space-y-1 pl-4">
+              <li>Reservas confirmadas não podem sobrepor horários ocupados.</li>
+              <li>Horários passados ficam indisponíveis automaticamente.</li>
+              <li>Recorrências semanais estão disponíveis para técnicos e administradores.</li>
+            </ul>
+          </div>
+        </aside>
+
+        <section className="space-y-6">
+          <Card>
+            <CardHeader className="flex flex-col gap-1">
+              <CardTitle className="text-xl">Horários disponíveis</CardTitle>
+              <p className="text-sm text-muted-foreground">
+                Clique nos horários livres para adicioná-los à reserva. Horários reservados exibem o responsável atual.
+              </p>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {schedule.periods.map((period) => (
+                <div key={period.id} className="space-y-3">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                      {period.label}
+                    </h3>
+                    <span className="text-xs text-muted-foreground">
+                      {period.slots.filter((slot) => !slot.isOccupied && !slot.isPast).length} disponíveis
+                    </span>
+                  </div>
+                  <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+                    {period.slots.map((slot) => (
+                      <SlotCard
+                        key={slot.id}
+                        slot={slot}
+                        isSelected={selectedSlots.has(slot.id)}
+                        onToggle={() => toggleSlotSelection(slot)}
+                        timeFormatter={timeFormatter}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+
+              <form action={formAction} className="space-y-4">
+                <input type="hidden" name="laboratoryId" value={selectedLaboratoryId} />
+                <input type="hidden" name="date" value={selectedDate} />
+                {selectedSlotIds.map((slotId) => (
+                  <input key={slotId} type="hidden" name="slotIds" value={slotId} />
+                ))}
+
+                {canScheduleRecurrence ? (
+                  <div className="space-y-2">
+                    <label htmlFor="occurrences" className="text-sm font-medium text-foreground">
+                      Recorrência semanal
+                    </label>
+                    <select
+                      id="occurrences"
+                      name="occurrences"
+                      defaultValue="1"
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                    >
+                      {OCCURRENCE_OPTIONS.map((option) => (
+                        <option key={option} value={option}>
+                          {option === 1
+                            ? "Não repetir"
+                            : `${option} semanas (${option} reservas)`}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ) : (
+                  <input type="hidden" name="occurrences" value="1" />
+                )}
+
+                <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="text-sm text-muted-foreground">
+                    {selectionSummary ?? "Nenhum horário selecionado."}
+                  </div>
+                  <Button
+                    type="submit"
+                    disabled={selectedSlotIds.length === 0 || isSubmitting}
+                    className="sm:w-auto"
+                  >
+                    {isSubmitting ? (
+                      <span className="flex items-center gap-2">
+                        <Loader2 className="size-4 animate-spin" aria-hidden />
+                        Registrando reserva…
+                      </span>
+                    ) : (
+                      "Confirmar reserva"
+                    )}
+                  </Button>
+                </div>
+
+                {formState.status !== "idle" ? (
+                  <div
+                    role="status"
+                    className={cn(
+                      "rounded-md border px-3 py-2 text-sm",
+                      formState.status === "success"
+                        ? "border-emerald-600/40 bg-emerald-50 text-emerald-700"
+                        : "border-destructive/50 bg-destructive/10 text-destructive",
+                    )}
+                  >
+                    {formState.message}
+                  </div>
+                ) : null}
+              </form>
+            </CardContent>
+          </Card>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+interface SlotCardProps {
+  slot: ReservationSlot;
+  isSelected: boolean;
+  onToggle: () => void;
+  timeFormatter: Intl.DateTimeFormat;
+}
+
+function SlotCard({ slot, isSelected, onToggle, timeFormatter }: SlotCardProps) {
+  const isDisabled = slot.isOccupied || slot.isPast;
+  const start = timeFormatter.format(new Date(slot.startTime));
+  const end = timeFormatter.format(new Date(slot.endTime));
+
+  const statusLabel = getStatusLabel(slot);
+
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      disabled={isDisabled}
+      className={cn(
+        "flex w-full flex-col gap-1 rounded-lg border border-border/60 px-3 py-3 text-left text-sm shadow-sm transition-all",
+        isDisabled && "bg-muted/60 text-muted-foreground",
+        isSelected && !isDisabled && "border-primary bg-primary/10 text-primary",
+        !isSelected && !isDisabled && "hover:border-primary/70 hover:bg-primary/5",
+      )}
+    >
+      <div className="flex items-center justify-between">
+        <span className="font-medium">{start} - {end}</span>
+        {slot.isOccupied ? (
+          <span className="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+            Ocupado
+          </span>
+        ) : slot.isPast ? (
+          <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            Encerrado
+          </span>
+        ) : isSelected ? (
+          <span className="rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground">
+            Selecionado
+          </span>
+        ) : (
+          <span className="rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-medium text-emerald-700">
+            Disponível
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-muted-foreground">{statusLabel}</p>
+    </button>
+  );
+}
+
+function getStatusLabel(slot: ReservationSlot): string {
+  if (slot.isOccupied && slot.reservation) {
+    const owner = slot.reservation.createdBy.name;
+    const statusText =
+      slot.reservation.status === ReservationStatus.PENDING ? "aguardando confirmação" : "confirmada";
+    return `Reservado por ${owner} (${statusText})`;
+  }
+
+  if (slot.isPast) {
+    return "Horário indisponível.";
+  }
+
+  return "Horário livre para reserva.";
+}
+
+function findSlot(schedule: DailySchedule, slotId: string): ReservationSlot | null {
+  for (const period of schedule.periods) {
+    const match = period.slots.find((slot) => slot.id === slotId);
+    if (match) {
+      return match;
+    }
+  }
+
+  return null;
+}

--- a/src/features/scheduling/server/actions.ts
+++ b/src/features/scheduling/server/actions.ts
@@ -1,0 +1,241 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { ReservationStatus, Role } from "@prisma/client";
+
+import { auth } from "@/auth";
+import { prisma } from "@/lib/prisma";
+import type { ActionState } from "@/features/shared/types";
+import { getSystemRules } from "@/features/system-rules/server/queries";
+
+const MAX_OCCURRENCES = 26;
+
+const createReservationSchema = z.object({
+  laboratoryId: z.string().min(1, "Selecione um laboratório válido."),
+  date: z
+    .string()
+    .regex(/^(\\d{4})-(\\d{2})-(\\d{2})$/, "Informe uma data válida."),
+  slotIds: z
+    .array(z.string().min(1))
+    .min(1, "Selecione pelo menos um horário."),
+  occurrences: z
+    .string()
+    .optional()
+    .transform((value) => {
+      if (!value) {
+        return 1;
+      }
+
+      const parsed = Number.parseInt(value, 10);
+
+      if (!Number.isFinite(parsed) || parsed < 1) {
+        return 1;
+      }
+
+      return Math.min(parsed, MAX_OCCURRENCES);
+    }),
+});
+
+export async function createReservationAction(
+  _prev: ActionState,
+  formData: FormData,
+): Promise<ActionState> {
+  const session = await auth();
+
+  if (!session?.user) {
+    return {
+      status: "error",
+      message: "Você precisa estar autenticado para reservar um laboratório.",
+    };
+  }
+
+  const rawSlotIds = formData
+    .getAll("slotIds")
+    .filter((value): value is string => typeof value === "string" && value.length > 0);
+
+  const parsed = createReservationSchema.safeParse({
+    laboratoryId: formData.get("laboratoryId"),
+    date: formData.get("date"),
+    slotIds: rawSlotIds,
+    occurrences: formData.get("occurrences"),
+  });
+
+  if (!parsed.success) {
+    const message = parsed.error.issues[0]?.message ?? "Não foi possível validar a reserva.";
+    return { status: "error", message };
+  }
+
+  const { laboratoryId, date, slotIds } = parsed.data;
+  let occurrences = parsed.data.occurrences ?? 1;
+
+  if (occurrences > 1 && session.user.role === Role.PROFESSOR) {
+    occurrences = 1;
+  }
+
+  const slots = slotIds
+    .map((slotId) => ({
+      id: slotId,
+      start: new Date(slotId),
+    }))
+    .sort((left, right) => left.start.getTime() - right.start.getTime());
+
+  if (slots.some((slot) => Number.isNaN(slot.start.getTime()))) {
+    return {
+      status: "error",
+      message: "Horário selecionado inválido. Atualize a página e tente novamente.",
+    };
+  }
+
+  const isSameDay = slots.every((slot) => slot.start.toISOString().startsWith(`${date}T`));
+
+  if (!isSameDay) {
+    return {
+      status: "error",
+      message: "Todos os horários devem pertencer ao mesmo dia.",
+    };
+  }
+
+  const uniqueSlots = Array.from(new Set(slots.map((slot) => slot.id)));
+
+  if (uniqueSlots.length !== slots.length) {
+    return {
+      status: "error",
+      message: "Não é possível selecionar o mesmo horário mais de uma vez.",
+    };
+  }
+
+  const slotDurationMinutes = await inferSlotDurationMinutes(laboratoryId);
+
+  if (!slotDurationMinutes) {
+    return {
+      status: "error",
+      message: "Não foi possível validar os horários da reserva.",
+    };
+  }
+
+  const reservationStart = slots[0]!.start;
+  const reservationEnd = new Date(
+    slots[slots.length - 1]!.start.getTime() + slotDurationMinutes * 60_000,
+  );
+
+  try {
+    await prisma.$transaction(async (tx) => {
+      let recurrenceId: string | null = null;
+
+      if (occurrences > 1 && session.user.role !== Role.PROFESSOR) {
+        const recurrence = await tx.reservationRecurrence.create({
+          data: {
+            laboratoryId,
+            createdById: session.user.id,
+            frequency: "WEEKLY",
+            interval: 1,
+            weekDay: reservationStart.getUTCDay(),
+            startDate: reservationStart,
+            endDate: new Date(
+              reservationEnd.getTime() + (occurrences - 1) * 7 * 24 * 60 * 60_000,
+            ),
+          },
+          select: { id: true },
+        });
+
+        recurrenceId = recurrence.id;
+      }
+
+      for (let occurrenceIndex = 0; occurrenceIndex < occurrences; occurrenceIndex += 1) {
+        const offset = occurrenceIndex * 7 * 24 * 60 * 60_000;
+        const occurrenceStart = new Date(reservationStart.getTime() + offset);
+        const occurrenceEnd = new Date(reservationEnd.getTime() + offset);
+
+        const hasConflict = await tx.reservation.findFirst({
+          where: {
+            laboratoryId,
+            status: { not: ReservationStatus.CANCELLED },
+            startTime: { lt: occurrenceEnd },
+            endTime: { gt: occurrenceStart },
+          },
+          select: { id: true },
+        });
+
+        if (hasConflict) {
+          throw new ReservationConflictError(occurrenceStart);
+        }
+
+        await tx.reservation.create({
+          data: {
+            laboratoryId,
+            createdById: session.user.id,
+            startTime: occurrenceStart,
+            endTime: occurrenceEnd,
+            status: ReservationStatus.CONFIRMED,
+            recurrenceId: recurrenceId ?? undefined,
+          },
+        });
+      }
+    });
+  } catch (error) {
+    if (error instanceof ReservationConflictError) {
+      const formatted = new Intl.DateTimeFormat("pt-BR", {
+        dateStyle: "short",
+        timeStyle: "short",
+      }).format(error.date);
+
+      return {
+        status: "error",
+        message: "Já existe uma reserva confirmada para " +
+          formatted +
+          ". Selecione outro horário.",
+      };
+    }
+
+    console.error("[scheduling] Failed to create reservation", error);
+    return {
+      status: "error",
+      message: "Não foi possível criar a reserva. Tente novamente mais tarde.",
+    };
+  }
+
+  revalidatePath("/dashboard/scheduling");
+  revalidatePath("/dashboard/scheduling/agenda");
+  revalidatePath("/dashboard/scheduling/history");
+
+  const successMessage =
+    occurrences > 1
+      ? "Recorrência criada com sucesso. Todas as reservas foram confirmadas."
+      : "Reserva confirmada com sucesso.";
+
+  return { status: "success", message: successMessage };
+}
+
+class ReservationConflictError extends Error {
+  constructor(public readonly date: Date) {
+    super("Reservation conflict");
+  }
+}
+
+async function inferSlotDurationMinutes(laboratoryId: string): Promise<number | null> {
+  const latestReservation = await prisma.reservation.findFirst({
+    where: { laboratoryId },
+    orderBy: { startTime: "desc" },
+    select: { startTime: true, endTime: true },
+  });
+
+  if (latestReservation) {
+    const difference =
+      (latestReservation.endTime.getTime() - latestReservation.startTime.getTime()) / 60_000;
+
+    if (Number.isFinite(difference) && difference > 0) {
+      return Math.round(difference);
+    }
+  }
+
+  const systemRules = await getSystemRules();
+  const periods = Object.values(systemRules.periods);
+
+  if (periods.length === 0) {
+    return null;
+  }
+
+  const duration = periods[0]?.classDurationMinutes;
+  return typeof duration === "number" && Number.isFinite(duration) ? duration : null;
+}

--- a/src/features/scheduling/server/queries.ts
+++ b/src/features/scheduling/server/queries.ts
@@ -1,0 +1,220 @@
+import { ReservationStatus, Role } from "@prisma/client";
+
+import { prisma } from "@/lib/prisma";
+import { getSystemRules } from "@/features/system-rules/server/queries";
+import { buildDailySchedule } from "@/features/scheduling/utils";
+import type {
+  AgendaReservation,
+  DailySchedule,
+  ReservationHistoryEntry,
+  SerializableLaboratoryOption,
+  SerializableReservationSummary,
+} from "@/features/scheduling/types";
+
+interface GetSchedulingBoardOptions {
+  laboratoryId: string;
+  date: string;
+  now: Date;
+}
+
+export async function getSchedulingBoardData({
+  laboratoryId,
+  date,
+  now,
+}: GetSchedulingBoardOptions): Promise<DailySchedule> {
+  const [systemRules, reservations] = await Promise.all([
+    getSystemRules(),
+    getReservationsForDay({ laboratoryId, date }),
+  ]);
+
+  return buildDailySchedule({
+    date,
+    systemRules,
+    reservations,
+    now,
+  });
+}
+
+export async function getActiveLaboratoryOptions(): Promise<SerializableLaboratoryOption[]> {
+  const laboratories = await prisma.laboratory.findMany({
+    where: { status: "ACTIVE" },
+    orderBy: { name: "asc" },
+    select: {
+      id: true,
+      name: true,
+    },
+  });
+
+  return laboratories.map((laboratory) => ({
+    id: laboratory.id,
+    name: laboratory.name,
+  }));
+}
+
+interface GetReservationsForDayOptions {
+  laboratoryId: string;
+  date: string;
+}
+
+export async function getReservationsForDay({
+  laboratoryId,
+  date,
+}: GetReservationsForDayOptions): Promise<SerializableReservationSummary[]> {
+  const startOfDay = new Date(`${date}T00:00:00.000Z`);
+  const endOfDay = new Date(startOfDay.getTime() + 24 * 60 * 60_000);
+
+  const reservations = await prisma.reservation.findMany({
+    where: {
+      laboratoryId,
+      startTime: { lt: endOfDay },
+      endTime: { gt: startOfDay },
+      status: { not: ReservationStatus.CANCELLED },
+    },
+    orderBy: { startTime: "asc" },
+    select: {
+      id: true,
+      laboratoryId: true,
+      startTime: true,
+      endTime: true,
+      status: true,
+      recurrenceId: true,
+      createdBy: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  return reservations.map((reservation) => ({
+    id: reservation.id,
+    laboratoryId: reservation.laboratoryId,
+    startTime: reservation.startTime.toISOString(),
+    endTime: reservation.endTime.toISOString(),
+    status: reservation.status,
+    recurrenceId: reservation.recurrenceId,
+    createdBy: {
+      id: reservation.createdBy.id,
+      name: reservation.createdBy.name,
+    },
+  }));
+}
+
+export async function getUpcomingReservations(
+  actor: { id: string; role: Role },
+): Promise<AgendaReservation[]> {
+  const now = new Date();
+  const canViewAll = actor.role === Role.TECHNICIAN || actor.role === Role.ADMIN;
+
+  const reservations = await prisma.reservation.findMany({
+    where: {
+      ...(canViewAll ? {} : { createdById: actor.id }),
+      status: { in: [ReservationStatus.PENDING, ReservationStatus.CONFIRMED] },
+      endTime: { gte: now },
+    },
+    orderBy: { startTime: "asc" },
+    take: 100,
+    select: {
+      id: true,
+      laboratoryId: true,
+      startTime: true,
+      endTime: true,
+      status: true,
+      recurrenceId: true,
+      createdBy: {
+        select: { id: true, name: true },
+      },
+      laboratory: {
+        select: { id: true, name: true },
+      },
+    },
+  });
+
+  return reservations.map((reservation) => ({
+    id: reservation.id,
+    laboratoryId: reservation.laboratoryId,
+    startTime: reservation.startTime.toISOString(),
+    endTime: reservation.endTime.toISOString(),
+    status: reservation.status,
+    recurrenceId: reservation.recurrenceId,
+    createdBy: {
+      id: reservation.createdBy.id,
+      name: reservation.createdBy.name,
+    },
+    laboratory: {
+      id: reservation.laboratory.id,
+      name: reservation.laboratory.name,
+    },
+  }));
+}
+
+export async function getReservationHistory(
+  actor: { id: string; role: Role },
+): Promise<ReservationHistoryEntry[]> {
+  const canViewAll = actor.role === Role.TECHNICIAN || actor.role === Role.ADMIN;
+
+  const reservations = await prisma.reservation.findMany({
+    where: {
+      ...(canViewAll ? {} : { createdById: actor.id }),
+    },
+    orderBy: { startTime: "desc" },
+    take: 250,
+    select: {
+      id: true,
+      laboratoryId: true,
+      startTime: true,
+      endTime: true,
+      status: true,
+      recurrenceId: true,
+      cancellationReason: true,
+      cancelledAt: true,
+      createdBy: {
+        select: { id: true, name: true },
+      },
+      laboratory: {
+        select: { id: true, name: true },
+      },
+    },
+  });
+
+  return reservations.map((reservation) => ({
+    id: reservation.id,
+    laboratoryId: reservation.laboratoryId,
+    startTime: reservation.startTime.toISOString(),
+    endTime: reservation.endTime.toISOString(),
+    status: reservation.status,
+    recurrenceId: reservation.recurrenceId,
+    cancellationReason: reservation.cancellationReason,
+    cancelledAt: reservation.cancelledAt?.toISOString() ?? null,
+    createdBy: {
+      id: reservation.createdBy.id,
+      name: reservation.createdBy.name,
+    },
+    laboratory: {
+      id: reservation.laboratory.id,
+      name: reservation.laboratory.name,
+    },
+  }));
+}
+
+export function normalizeDateParam(rawDate?: string | string[]): string {
+  const value = Array.isArray(rawDate) ? rawDate[0] : rawDate;
+  if (!value) {
+    return formatDate(new Date());
+  }
+
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!match) {
+    return formatDate(new Date());
+  }
+
+  return value;
+}
+
+function formatDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}

--- a/src/features/scheduling/types.ts
+++ b/src/features/scheduling/types.ts
@@ -1,0 +1,68 @@
+import type { ReservationStatus, Role } from "@prisma/client";
+
+import type { PeriodId } from "@/features/system-rules/constants";
+
+export interface SerializableLaboratoryOption {
+  id: string;
+  name: string;
+}
+
+export interface SerializableReservationSummary {
+  id: string;
+  laboratoryId: string;
+  startTime: string;
+  endTime: string;
+  status: ReservationStatus;
+  createdBy: {
+    id: string;
+    name: string;
+  };
+  recurrenceId?: string | null;
+}
+
+export interface ReservationSlot {
+  id: string;
+  periodId: PeriodId;
+  classIndex: number;
+  startTime: string;
+  endTime: string;
+  isOccupied: boolean;
+  isPast: boolean;
+  reservation?: SerializableReservationSummary;
+}
+
+export interface PeriodSchedule {
+  id: PeriodId;
+  label: string;
+  slots: ReservationSlot[];
+}
+
+export interface DailySchedule {
+  date: string;
+  periods: PeriodSchedule[];
+}
+
+export interface AgendaReservation extends SerializableReservationSummary {
+  laboratory: {
+    id: string;
+    name: string;
+  };
+}
+
+export interface ReservationHistoryEntry extends AgendaReservation {
+  cancellationReason?: string | null;
+  cancelledAt?: string | null;
+}
+
+export interface SchedulingBoardData {
+  laboratories: SerializableLaboratoryOption[];
+  selectedLaboratoryId: string;
+  selectedDate: string;
+  schedule: DailySchedule;
+  actorRole: Role;
+}
+
+export type ReservationActionState = {
+  status: "idle" | "success" | "error";
+  message?: string;
+};

--- a/src/features/scheduling/utils.ts
+++ b/src/features/scheduling/utils.ts
@@ -1,0 +1,199 @@
+import { ReservationStatus } from "@prisma/client";
+
+import { PERIOD_IDS, type PeriodId } from "@/features/system-rules/constants";
+import { parseTimeToMinutes } from "@/features/system-rules/utils";
+
+import type {
+  DailySchedule,
+  PeriodSchedule,
+  ReservationSlot,
+  SerializableReservationSummary,
+} from "@/features/scheduling/types";
+import type { SerializableSystemRules } from "@/features/system-rules/types";
+
+interface BuildDailyScheduleOptions {
+  date: string;
+  systemRules: SerializableSystemRules;
+  reservations: SerializableReservationSummary[];
+  now: Date;
+}
+
+interface IntervalDefinition {
+  start: number;
+  durationMinutes: number;
+}
+
+interface PeriodDefinition {
+  id: PeriodId;
+  label: string;
+  firstClassTime: number;
+  classDurationMinutes: number;
+  classesCount: number;
+  intervals: IntervalDefinition[];
+}
+
+const PERIOD_LABELS: Record<PeriodId, string> = {
+  morning: "Manhã",
+  afternoon: "Tarde",
+  evening: "Noite",
+};
+
+export function buildDailySchedule({
+  date,
+  systemRules,
+  reservations,
+  now,
+}: BuildDailyScheduleOptions): DailySchedule {
+  const baseDate = buildStartOfDay(date);
+  const baseTimestamp = baseDate.getTime();
+  const normalizedReservations = reservations.map((reservation) => ({
+    ...reservation,
+    startTimestamp: new Date(reservation.startTime).getTime(),
+    endTimestamp: new Date(reservation.endTime).getTime(),
+  }));
+
+  const nowTimestamp = now.getTime();
+
+  const periods: PeriodSchedule[] = PERIOD_IDS.map((periodId) => {
+    const rule = systemRules.periods[periodId];
+
+    if (!rule) {
+      return {
+        id: periodId,
+        label: PERIOD_LABELS[periodId],
+        slots: [],
+      } satisfies PeriodSchedule;
+    }
+
+    const definition: PeriodDefinition = {
+      id: periodId,
+      label: PERIOD_LABELS[periodId],
+      firstClassTime: parseTimeToMinutes(rule.firstClassTime),
+      classDurationMinutes: rule.classDurationMinutes,
+      classesCount: rule.classesCount,
+      intervals: [...(rule.intervals ?? [])]
+        .map((interval) => ({
+          start: parseTimeToMinutes(interval.start),
+          durationMinutes: interval.durationMinutes,
+        }))
+        .sort((left, right) => left.start - right.start),
+    };
+
+    const slots = buildPeriodSlots({
+      baseTimestamp,
+      nowTimestamp,
+      reservations: normalizedReservations,
+      definition,
+    });
+
+    return {
+      id: periodId,
+      label: definition.label,
+      slots,
+    } satisfies PeriodSchedule;
+  });
+
+  return { date, periods };
+}
+
+interface BuildPeriodSlotsOptions {
+  baseTimestamp: number;
+  nowTimestamp: number;
+  reservations: Array<SerializableReservationSummary & {
+    startTimestamp: number;
+    endTimestamp: number;
+  }>;
+  definition: PeriodDefinition;
+}
+
+function buildPeriodSlots({
+  baseTimestamp,
+  nowTimestamp,
+  reservations,
+  definition,
+}: BuildPeriodSlotsOptions): ReservationSlot[] {
+  const slots: ReservationSlot[] = [];
+  const intervals = definition.intervals;
+  let intervalIndex = 0;
+  let currentMinutes = definition.firstClassTime;
+
+  for (let index = 0; index < definition.classesCount; index += 1) {
+    while (intervalIndex < intervals.length && currentMinutes >= intervals[intervalIndex]!.start) {
+      currentMinutes = Math.max(currentMinutes, intervals[intervalIndex]!.start) +
+        intervals[intervalIndex]!.durationMinutes;
+      intervalIndex += 1;
+    }
+
+    const nextInterval = intervals[intervalIndex];
+    if (
+      nextInterval &&
+      currentMinutes + definition.classDurationMinutes > nextInterval.start
+    ) {
+      currentMinutes = Math.max(currentMinutes, nextInterval.start) +
+        nextInterval.durationMinutes;
+      intervalIndex += 1;
+    }
+
+    const slotStart = baseTimestamp + currentMinutes * 60_000;
+    const slotEnd = slotStart + definition.classDurationMinutes * 60_000;
+
+    const conflictingReservation = findConflictingReservation(
+      reservations,
+      slotStart,
+      slotEnd,
+    );
+
+    const isOccupied =
+      conflictingReservation !== null &&
+      conflictingReservation.status !== ReservationStatus.CANCELLED;
+
+    slots.push({
+      id: new Date(slotStart).toISOString(),
+      periodId: definition.id,
+      classIndex: index + 1,
+      startTime: new Date(slotStart).toISOString(),
+      endTime: new Date(slotEnd).toISOString(),
+      isOccupied,
+      isPast: slotEnd <= nowTimestamp,
+      reservation: conflictingReservation ?? undefined,
+    });
+
+    currentMinutes += definition.classDurationMinutes;
+  }
+
+  return slots;
+}
+
+function findConflictingReservation(
+  reservations: Array<SerializableReservationSummary & {
+    startTimestamp: number;
+    endTimestamp: number;
+  }>,
+  slotStart: number,
+  slotEnd: number,
+): (SerializableReservationSummary & {
+  startTimestamp: number;
+  endTimestamp: number;
+}) | null {
+  for (const reservation of reservations) {
+    if (reservation.status === ReservationStatus.CANCELLED) {
+      continue;
+    }
+
+    const overlaps = reservation.startTimestamp < slotEnd && reservation.endTimestamp > slotStart;
+
+    if (overlaps) {
+      return reservation;
+    }
+  }
+
+  return null;
+}
+
+function buildStartOfDay(date: string): Date {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error(`Invalid ISO date: ${date}`);
+  }
+
+  return new Date(`${date}T00:00:00.000Z`);
+}


### PR DESCRIPTION
## Summary
- add interactive scheduling board with calendar navigation, slot selection and weekly recurrence controls
- implement reservation server actions and queries to enforce conflicts, generate daily schedules and support agendas
- expose agenda and history dashboards for reservations and surface the scheduling module in the main navigation

## Testing
- pnpm lint
- CI=1 pnpm build

------
https://chatgpt.com/codex/tasks/task_b_69020713b39c8327af575d28b56214fa