### PR TITLE
Fix system rules cache updates

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,7 +59,7 @@ export default async function RootLayout({
   }) as CSSProperties;
 
   return (
-    <html lang="pt-BR" suppressHydrationWarning>
+    <html lang="pt-BR" suppressHydrationWarning style={paletteStyles}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: THEME_INITIALIZATION_SCRIPT }} />
       </head>

--- a/src/features/system-rules/server/actions.ts
+++ b/src/features/system-rules/server/actions.ts
@@ -2,7 +2,7 @@
 
 import { Buffer } from "node:buffer";
 
-import { revalidatePath } from "next/cache";
+import { revalidatePath, revalidateTag } from "next/cache";
 import { z } from "zod";
 import { Role } from "@prisma/client";
 
@@ -582,6 +582,7 @@ export async function updateSystemRulesAction(
     type: "update",
   });
 
+  revalidateTag("system-rules");
   revalidatePath("/system-rules");
   revalidatePath("/", "layout");
   revalidatePath("/users");

--- a/src/features/system-rules/server/actions.ts
+++ b/src/features/system-rules/server/actions.ts
@@ -582,7 +582,7 @@ export async function updateSystemRulesAction(
     type: "update",
   });
 
-  revalidateTag("system-rules");
+  revalidateTag("system-rules", "max");
   revalidatePath("/system-rules");
   revalidatePath("/", "layout");
   revalidatePath("/users");

--- a/src/features/system-rules/server/queries.ts
+++ b/src/features/system-rules/server/queries.ts
@@ -1,4 +1,5 @@
-import { unstable_cache } from "next/cache";
+import { unstable_noStore as noStore } from "next/cache";
+import { cache } from "react";
 import type { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
@@ -39,6 +40,8 @@ type BrandingRuleValues = {
 };
 
 async function loadSystemRules(): Promise<SerializableSystemRules> {
+  noStore();
+
   const fallbackSchedule: ScheduleRuleMinutes = {
     timeZone: DEFAULT_SYSTEM_RULES.schedule.timeZone,
     periods: DEFAULT_SYSTEM_RULES.schedule.periods,
@@ -120,11 +123,13 @@ async function loadSystemRules(): Promise<SerializableSystemRules> {
   }
 }
 
-export const getSystemRules = unstable_cache(loadSystemRules, ["system-rules"], {
-  tags: ["system-rules"],
+export const getSystemRules = cache(async (): Promise<SerializableSystemRules> => {
+  return loadSystemRules();
 });
 
 async function loadAllowedEmailDomains(): Promise<string[]> {
+  noStore();
+
   const audit = createAuditSpan(
     { module: "system-rules", action: "getAllowedEmailDomains" },
     undefined,
@@ -154,11 +159,9 @@ async function loadAllowedEmailDomains(): Promise<string[]> {
   }
 }
 
-export const getAllowedEmailDomains = unstable_cache(
-  loadAllowedEmailDomains,
-  ["allowed-email-domains"],
-  { tags: ["system-rules"] },
-);
+export const getAllowedEmailDomains = cache(async (): Promise<string[]> => {
+  return loadAllowedEmailDomains();
+});
 
 function mapToSerializable(
   schedule: ScheduleRuleMinutes,

--- a/src/features/system-rules/server/queries.ts
+++ b/src/features/system-rules/server/queries.ts
@@ -1,3 +1,4 @@
+import { unstable_cache } from "next/cache";
 import type { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
@@ -37,7 +38,7 @@ type BrandingRuleValues = {
   institutionName: string;
 };
 
-export async function getSystemRules(): Promise<SerializableSystemRules> {
+async function loadSystemRules(): Promise<SerializableSystemRules> {
   const fallbackSchedule: ScheduleRuleMinutes = {
     timeZone: DEFAULT_SYSTEM_RULES.schedule.timeZone,
     periods: DEFAULT_SYSTEM_RULES.schedule.periods,
@@ -119,7 +120,11 @@ export async function getSystemRules(): Promise<SerializableSystemRules> {
   }
 }
 
-export async function getAllowedEmailDomains(): Promise<string[]> {
+export const getSystemRules = unstable_cache(loadSystemRules, ["system-rules"], {
+  tags: ["system-rules"],
+});
+
+async function loadAllowedEmailDomains(): Promise<string[]> {
   const audit = createAuditSpan(
     { module: "system-rules", action: "getAllowedEmailDomains" },
     undefined,
@@ -148,6 +153,12 @@ export async function getAllowedEmailDomains(): Promise<string[]> {
     return [...DEFAULT_SYSTEM_RULES.account.allowedEmailDomains];
   }
 }
+
+export const getAllowedEmailDomains = unstable_cache(
+  loadAllowedEmailDomains,
+  ["allowed-email-domains"],
+  { tags: ["system-rules"] },
+);
 
 function mapToSerializable(
   schedule: ScheduleRuleMinutes,

--- a/src/features/system-rules/server/queries.ts
+++ b/src/features/system-rules/server/queries.ts
@@ -1,5 +1,4 @@
-import { unstable_noStore as noStore } from "next/cache";
-import { cache } from "react";
+import { unstable_cache, unstable_noStore as noStore } from "next/cache";
 import type { Prisma } from "@prisma/client";
 
 import { prisma } from "@/lib/prisma";
@@ -123,8 +122,8 @@ async function loadSystemRules(): Promise<SerializableSystemRules> {
   }
 }
 
-export const getSystemRules = cache(async (): Promise<SerializableSystemRules> => {
-  return loadSystemRules();
+export const getSystemRules = unstable_cache(loadSystemRules, ["system-rules"], {
+  tags: ["system-rules"],
 });
 
 async function loadAllowedEmailDomains(): Promise<string[]> {
@@ -159,9 +158,11 @@ async function loadAllowedEmailDomains(): Promise<string[]> {
   }
 }
 
-export const getAllowedEmailDomains = cache(async (): Promise<string[]> => {
-  return loadAllowedEmailDomains();
-});
+export const getAllowedEmailDomains = unstable_cache(
+  loadAllowedEmailDomains,
+  ["allowed-email-domains"],
+  { tags: ["system-rules"] },
+);
 
 function mapToSerializable(
   schedule: ScheduleRuleMinutes,


### PR DESCRIPTION
## Summary
- cache system rules queries with a shared tag to support global invalidation
- trigger tag revalidation after updating system rules so new color palettes propagate on refresh

## Testing
- pnpm lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926e5692890832c849172278d1a8345)